### PR TITLE
【feature/9】認証フローUTの実装

### DIFF
--- a/app/api/routes/tracks.py
+++ b/app/api/routes/tracks.py
@@ -8,7 +8,7 @@ router = APIRouter()
 @router.get("/{track_id}")
 async def get_track(track_id: str, authorization: str = Header(...)):
     """トラック情報取得"""
-    
+
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(
@@ -17,9 +17,14 @@ async def get_track(track_id: str, authorization: str = Header(...)):
             )
             response.raise_for_status()
             return response.json()
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=f"Failed to fetch track: {str(e)}"
+            )
         except httpx.HTTPError as e:
             raise HTTPException(
-                status_code=response.status_code if hasattr(response, 'status_code') else 500,
+                status_code=500,
                 detail=f"Failed to fetch track: {str(e)}"
             )
 
@@ -27,7 +32,7 @@ async def get_track(track_id: str, authorization: str = Header(...)):
 @router.get("/{track_id}/features")
 async def get_audio_features(track_id: str, authorization: str = Header(...)):
     """Audio Features取得"""
-    
+
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(
@@ -36,8 +41,13 @@ async def get_audio_features(track_id: str, authorization: str = Header(...)):
             )
             response.raise_for_status()
             return response.json()
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=f"Failed to fetch audio features: {str(e)}"
+            )
         except httpx.HTTPError as e:
             raise HTTPException(
-                status_code=response.status_code if hasattr(response, 'status_code') else 500,
+                status_code=500,
                 detail=f"Failed to fetch audio features: {str(e)}"
             )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,4 +1,5 @@
 from pydantic_settings import BaseSettings
+from pydantic import ConfigDict
 
 
 class Settings(BaseSettings):
@@ -21,9 +22,11 @@ class Settings(BaseSettings):
     SPOTIFY_TOKEN_URL: str = "https://accounts.spotify.com/api/token"
     SPOTIFY_API_BASE_URL: str = "https://api.spotify.com/v1"
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    model_config = ConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore"  # 余分な環境変数を無視
+    )
 
 
 settings = Settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""テスト用の共通フィクスチャ"""
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.config import settings
+
+
+@pytest.fixture
+def client():
+    """FastAPIテストクライアント"""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_settings(monkeypatch):
+    """モック設定"""
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_ID", "test_client_id")
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_SECRET", "test_client_secret")
+    monkeypatch.setattr(settings, "REDIRECT_URI", "http://localhost:3000/callback")
+    monkeypatch.setattr(settings, "ALLOWED_ORIGINS", "http://localhost:3000")
+    monkeypatch.setattr(settings, "ENVIRONMENT", "test")
+    monkeypatch.setattr(settings, "SPOTIFY_AUTH_URL", "https://accounts.spotify.com/authorize")
+    monkeypatch.setattr(settings, "SPOTIFY_TOKEN_URL", "https://accounts.spotify.com/api/token")
+    monkeypatch.setattr(settings, "SPOTIFY_API_BASE_URL", "https://api.spotify.com/v1")
+    return settings
+
+
+@pytest.fixture
+def sample_token_response():
+    """サンプルトークンレスポンス"""
+    return {
+        "access_token": "test_access_token",
+        "refresh_token": "test_refresh_token",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "user-read-private user-read-email"
+    }
+
+
+@pytest.fixture
+def sample_track_data():
+    """サンプルトラックデータ"""
+    return {
+        "id": "test_track_id",
+        "name": "Test Track",
+        "artists": [
+            {
+                "id": "test_artist_id",
+                "name": "Test Artist"
+            }
+        ],
+        "album": {
+            "id": "test_album_id",
+            "name": "Test Album",
+            "release_date": "2024-01-01"
+        },
+        "duration_ms": 180000,
+        "popularity": 75
+    }
+
+
+@pytest.fixture
+def sample_audio_features():
+    """サンプルオーディオ特徴データ"""
+    return {
+        "id": "test_track_id",
+        "danceability": 0.8,
+        "energy": 0.7,
+        "key": 5,
+        "loudness": -5.0,
+        "mode": 1,
+        "speechiness": 0.05,
+        "acousticness": 0.1,
+        "instrumentalness": 0.0,
+        "liveness": 0.2,
+        "valence": 0.6,
+        "tempo": 120.0,
+        "duration_ms": 180000,
+        "time_signature": 4
+    }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,153 @@
+"""認証ルートのユニットテスト"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+from app.core.config import settings
+
+
+class TestAuthLogin:
+    """ログインエンドポイントのテスト"""
+
+    def test_get_login_url_success(self, client):
+        """ログインURL生成が成功することを確認"""
+        response = client.get("/auth/login")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "auth_url" in data
+
+        # URLに必要なパラメータが含まれていることを確認
+        auth_url = data["auth_url"]
+        assert settings.SPOTIFY_AUTH_URL in auth_url
+        assert f"client_id={settings.SPOTIFY_CLIENT_ID}" in auth_url
+        assert "response_type=code" in auth_url
+        assert f"redirect_uri={settings.REDIRECT_URI}" in auth_url
+
+        # スコープが含まれていることを確認
+        assert "user-read-private" in auth_url
+        assert "user-read-email" in auth_url
+        assert "user-top-read" in auth_url
+        assert "user-read-recently-played" in auth_url
+
+
+class TestAuthCallback:
+    """コールバックエンドポイントのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_exchange_token_success(self, client, sample_token_response):
+        """トークン交換が成功することを確認"""
+        # httpx.AsyncClientのモック
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_token_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.post(
+                "/auth/callback",
+                json={"code": "test_auth_code"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["access_token"] == "test_access_token"
+            assert data["refresh_token"] == "test_refresh_token"
+            assert data["expires_in"] == 3600
+
+            # POSTリクエストが正しく呼ばれたことを確認
+            mock_client_instance.post.assert_called_once()
+            call_args = mock_client_instance.post.call_args
+            assert settings.SPOTIFY_TOKEN_URL in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_exchange_token_invalid_code(self, client):
+        """無効な認証コードでトークン交換が失敗することを確認"""
+        # HTTPエラーをシミュレート
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Invalid authorization code",
+            request=MagicMock(),
+            response=MagicMock(status_code=400)
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.post(
+                "/auth/callback",
+                json={"code": "invalid_code"}
+            )
+
+            assert response.status_code == 500
+            data = response.json()
+            assert "detail" in data
+            assert "Failed to exchange token" in data["detail"]
+
+    def test_exchange_token_missing_code(self, client):
+        """認証コードが欠けている場合にエラーになることを確認"""
+        response = client.post(
+            "/auth/callback",
+            json={}
+        )
+
+        # Pydanticのバリデーションエラー
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_exchange_token_network_error(self, client):
+        """ネットワークエラーが発生した場合の処理を確認"""
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.side_effect = httpx.ConnectError(
+                "Connection failed"
+            )
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.post(
+                "/auth/callback",
+                json={"code": "test_code"}
+            )
+
+            assert response.status_code == 500
+            data = response.json()
+            assert "Failed to exchange token" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_token_authorization_header(self, client, sample_token_response):
+        """Basic認証ヘッダーが正しく生成されることを確認"""
+        import base64
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_token_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.post(
+                "/auth/callback",
+                json={"code": "test_auth_code"}
+            )
+
+            assert response.status_code == 200
+
+            # POSTリクエストの引数を確認
+            call_args = mock_client_instance.post.call_args
+            headers = call_args.kwargs["headers"]
+
+            # Basic認証ヘッダーが存在することを確認
+            assert "Authorization" in headers
+            assert headers["Authorization"].startswith("Basic ")
+
+            # エンコードされた認証情報を確認
+            encoded = headers["Authorization"].replace("Basic ", "")
+            decoded = base64.b64decode(encoded).decode()
+            assert settings.SPOTIFY_CLIENT_ID in decoded
+            assert settings.SPOTIFY_CLIENT_SECRET in decoded

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,171 @@
+"""メインアプリケーションのユニットテスト"""
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+class TestHealthCheck:
+    """ヘルスチェックエンドポイントのテスト"""
+
+    def test_health_check(self, client):
+        """ヘルスチェックが正常に動作することを確認"""
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "status" in data
+        assert data["status"] == "ok"
+        assert "environment" in data
+
+    def test_health_check_returns_environment(self, client):
+        """ヘルスチェックが環境情報を返すことを確認"""
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data["environment"], str)
+
+
+class TestRootEndpoint:
+    """ルートエンドポイントのテスト"""
+
+    def test_root_endpoint(self, client):
+        """ルートエンドポイントが正常に動作することを確認"""
+        response = client.get("/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert data["message"] == "SoundLens API"
+
+    def test_root_endpoint_includes_documentation(self, client):
+        """ルートエンドポイントがドキュメントURLを含むことを確認"""
+        response = client.get("/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "docs" in data
+        assert data["docs"] == "/docs"
+
+    def test_root_endpoint_includes_version(self, client):
+        """ルートエンドポイントがバージョン情報を含むことを確認"""
+        response = client.get("/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert data["version"] == "1.0.0"
+
+
+class TestCORS:
+    """CORSミドルウェアのテスト"""
+
+    def test_cors_headers_present(self, client):
+        """CORSヘッダーが存在することを確認"""
+        response = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+
+        # Preflightリクエストの処理を確認
+        assert "access-control-allow-origin" in response.headers
+
+    def test_cors_allows_credentials(self, client):
+        """CORSが認証情報を許可することを確認"""
+        response = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+
+        headers = {k.lower(): v for k, v in response.headers.items()}
+        if "access-control-allow-credentials" in headers:
+            assert headers["access-control-allow-credentials"] == "true"
+
+
+class TestAPIDocumentation:
+    """APIドキュメントエンドポイントのテスト"""
+
+    def test_swagger_ui_accessible(self, client):
+        """Swagger UIがアクセス可能であることを確認"""
+        response = client.get("/docs")
+
+        assert response.status_code == 200
+        # HTMLが返されることを確認
+        assert "text/html" in response.headers["content-type"]
+
+    def test_redoc_accessible(self, client):
+        """ReDocがアクセス可能であることを確認"""
+        response = client.get("/redoc")
+
+        assert response.status_code == 200
+        # HTMLが返されることを確認
+        assert "text/html" in response.headers["content-type"]
+
+    def test_openapi_schema_accessible(self, client):
+        """OpenAPIスキーマがアクセス可能であることを確認"""
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "openapi" in data
+        assert "info" in data
+        assert data["info"]["title"] == "SoundLens API"
+        assert data["info"]["version"] == "1.0.0"
+
+    def test_openapi_schema_includes_routes(self, client):
+        """OpenAPIスキーマがルートを含むことを確認"""
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "paths" in data
+
+        # 主要なエンドポイントが含まれていることを確認
+        paths = data["paths"]
+        assert "/health" in paths
+        assert "/" in paths
+        assert "/auth/login" in paths
+        assert "/auth/callback" in paths
+        assert "/api/tracks/{track_id}" in paths
+        assert "/api/tracks/{track_id}/features" in paths
+
+
+class TestApplicationSetup:
+    """アプリケーションのセットアップのテスト"""
+
+    def test_app_title(self):
+        """アプリケーションのタイトルが正しいことを確認"""
+        assert app.title == "SoundLens API"
+
+    def test_app_description(self):
+        """アプリケーションの説明が正しいことを確認"""
+        assert app.description == "音楽分析・比較アプリケーション"
+
+    def test_app_version(self):
+        """アプリケーションのバージョンが正しいことを確認"""
+        assert app.version == "1.0.0"
+
+    def test_routes_registered(self, client):
+        """すべてのルートが登録されていることを確認"""
+        # OpenAPIスキーマからルート情報を取得
+        response = client.get("/openapi.json")
+        data = response.json()
+        paths = data["paths"]
+
+        # 認証ルート
+        assert "/auth/login" in paths
+        assert "/auth/callback" in paths
+
+        # トラックルート
+        assert "/api/tracks/{track_id}" in paths
+        assert "/api/tracks/{track_id}/features" in paths
+
+        # 基本ルート
+        assert "/health" in paths
+        assert "/" in paths

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -1,0 +1,265 @@
+"""トラックルートのユニットテスト"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+
+
+class TestGetTrack:
+    """トラック情報取得エンドポイントのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_get_track_success(self, client, sample_track_data):
+        """トラック情報の取得が成功することを確認"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_track_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["id"] == "test_track_id"
+            assert data["name"] == "Test Track"
+            assert data["artists"][0]["name"] == "Test Artist"
+
+            # GETリクエストが正しく呼ばれたことを確認
+            mock_client_instance.get.assert_called_once()
+            call_args = mock_client_instance.get.call_args
+            assert "tracks/test_track_id" in str(call_args)
+
+    def test_get_track_missing_authorization(self, client):
+        """認証ヘッダーが欠けている場合にエラーになることを確認"""
+        response = client.get("/api/tracks/test_track_id")
+
+        # 422 Unprocessable Entity (バリデーションエラー)
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_track_invalid_token(self, client):
+        """無効なトークンでエラーになることを確認"""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401)
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id",
+                headers={"Authorization": "Bearer invalid_token"}
+            )
+
+            assert response.status_code == 401
+            data = response.json()
+            assert "detail" in data
+
+    @pytest.mark.asyncio
+    async def test_get_track_not_found(self, client):
+        """存在しないトラックIDでエラーになることを確認"""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=MagicMock(),
+            response=MagicMock(status_code=404)
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/non_existent_track",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_track_network_error(self, client):
+        """ネットワークエラーが発生した場合の処理を確認"""
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.side_effect = httpx.ConnectError(
+                "Connection failed"
+            )
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 500
+            data = response.json()
+            assert "Failed to fetch track" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_get_track_authorization_header_forwarded(self, client, sample_track_data):
+        """認証ヘッダーがSpotify APIに正しく転送されることを確認"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_track_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            test_token = "Bearer test_access_token_123"
+            response = client.get(
+                "/api/tracks/test_track_id",
+                headers={"Authorization": test_token}
+            )
+
+            assert response.status_code == 200
+
+            # GETリクエストの引数を確認
+            call_args = mock_client_instance.get.call_args
+            headers = call_args.kwargs["headers"]
+            assert headers["Authorization"] == test_token
+
+
+class TestGetAudioFeatures:
+    """オーディオ特徴取得エンドポイントのテスト"""
+
+    @pytest.mark.asyncio
+    async def test_get_audio_features_success(self, client, sample_audio_features):
+        """オーディオ特徴の取得が成功することを確認"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_audio_features
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id/features",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["id"] == "test_track_id"
+            assert data["danceability"] == 0.8
+            assert data["energy"] == 0.7
+            assert data["tempo"] == 120.0
+
+            # GETリクエストが正しく呼ばれたことを確認
+            mock_client_instance.get.assert_called_once()
+            call_args = mock_client_instance.get.call_args
+            assert "audio-features/test_track_id" in str(call_args)
+
+    def test_get_audio_features_missing_authorization(self, client):
+        """認証ヘッダーが欠けている場合にエラーになることを確認"""
+        response = client.get("/api/tracks/test_track_id/features")
+
+        # 422 Unprocessable Entity (バリデーションエラー)
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_audio_features_invalid_token(self, client):
+        """無効なトークンでエラーになることを確認"""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401)
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id/features",
+                headers={"Authorization": "Bearer invalid_token"}
+            )
+
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_audio_features_not_found(self, client):
+        """存在しないトラックIDでエラーになることを確認"""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not Found",
+            request=MagicMock(),
+            response=MagicMock(status_code=404)
+        )
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/non_existent_track/features",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_audio_features_network_error(self, client):
+        """ネットワークエラーが発生した場合の処理を確認"""
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.side_effect = httpx.ConnectError(
+                "Connection failed"
+            )
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            response = client.get(
+                "/api/tracks/test_track_id/features",
+                headers={"Authorization": "Bearer test_access_token"}
+            )
+
+            assert response.status_code == 500
+            data = response.json()
+            assert "Failed to fetch audio features" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_get_audio_features_authorization_header_forwarded(self, client, sample_audio_features):
+        """認証ヘッダーがSpotify APIに正しく転送されることを確認"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_audio_features
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+            test_token = "Bearer test_access_token_456"
+            response = client.get(
+                "/api/tracks/test_track_id/features",
+                headers={"Authorization": test_token}
+            )
+
+            assert response.status_code == 200
+
+            # GETリクエストの引数を確認
+            call_args = mock_client_instance.get.call_args
+            headers = call_args.kwargs["headers"]
+            assert headers["Authorization"] == test_token


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
認証フローのUTを実装する

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #9 

## やったこと
<!-- このPRで何をしたのか -->
 1. tests/test_auth.py - 認証ルートのテスト（6テスト）
  テスト対象エンドポイント:
  - GET /auth/login - Spotify認証URL生成
  - POST /auth/callback - 認証コードをトークンに交換
2. tests/test_tracks.py - トラックルートのテスト（12テスト）
  テスト対象エンドポイント:
  - GET /api/tracks/{track_id} - トラック情報取得
  - GET /api/tracks/{track_id}/features - オーディオ特徴取得
3. tests/test_main.py - メインアプリのテスト（15テスト）
  テスト対象エンドポイント:
  - GET /health - ヘルスチェック
  - GET / - ルートエンドポイント
  - GET /docs - Swagger UI
  - GET /redoc - ReDoc

本番コードの修正
  1. app/core/config.py - 設定クラスの改善
  問題: .envファイルに余分な環境変数があるとPydanticがエラーを出す
  効果: Docker環境の環境変数（COMPOSE_PROJECT_NAMEなど）があってもエラーにならない
  2. app/api/routes/tracks.py - エラーハンドリングの改善
  問題: ネットワークエラー時にresponse変数が未定義でUnboundLocalErrorが発生
  効果:
  - HTTPステータスエラー（401, 404など）→ 実際のステータスコードをクライアントに返す
  - ネットワークエラー → 500エラーを返す

## やらないこと
<!-- このPRでやらないことは何か -->
- なし

## 動作確認
<!-- どのように動作確認を行なったか -->
- 全テストを実行
  docker-compose exec api pytest tests/ -v

- 特定のファイルのみ実行
  docker-compose exec api pytest tests/test_auth.py -v

- 特定のテストのみ実行
  docker-compose exec api pytest tests/test_auth.py::TestAuthLogin::test_get_login_url_success -v

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
- なし
